### PR TITLE
Adds css file to main in package.json and webpack instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,21 @@ Or with [npm](http://npmjs.com/):
 
     $ npm install framework7-icons
 
+## Webpack
+
+When using webpack, you must add loaders for css and fonts.
+
+```js
+{ test: /\.css/, loader: 'style-loader!css-loader' },
+{ test: /\.(woff|woff2|eot|ttf)$/, loader: 'url-loader?limit=100000' },
+```
+
+Then you can import the module like so:
+
+```js
+import 'framework7-icons';
+```
+
 
 ## HTML Example
 

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
   "name": "framework7-icons",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "description": "Free iOS-icons font for Framework7",
-  "main": "",
+  "main": "css/framework7-icons.css",
   "repository": {
     "type": "git",
     "url": "https://github.com/nolimits4web/Framework7-Icons.git"


### PR DESCRIPTION
This adds the css file as the main property in package.json.
This allows you to import the module using E.g webpack, without routing towards the css file manually.

It also adds documentation for how to use webpack, with loaders.

I also bumped the version to 0.9.1. If you'd rather do this yourself in a separate commit, say so, and I'll remove it from the PR.